### PR TITLE
Fixing merge title when nothing can be released

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ try {
         ...github.context.repo,
         pull_number: context.pullNumber,
         merge_method: 'squash',
-        commit_title: `merging v${version.display} into ${context.releaseTarget}`,
+        commit_title: context.status.canRelease ? `merging v${version.display} into ${context.releaseTarget}` : `merging pull #${context.pullNumber} into ${context.releaseTarget}`,
         commit_message: log(context)
       }))?.data.sha
 


### PR DESCRIPTION
[fix]-> correct title when no release is created for merges
This pull request closes #40 